### PR TITLE
style: 🎨 Fix dialog notes font color

### DIFF
--- a/src/styles/system/_app.scss
+++ b/src/styles/system/_app.scss
@@ -169,6 +169,10 @@ a.entity-link {
     color: var(--color-blue-lighter);
   }
 
+  form .notes, form .hint {
+    color: var(--color-green);
+  }
+
   /* ------------------------------------------ */
 
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
This PR fixes this font color:

![image](https://user-images.githubusercontent.com/47865544/205099452-0dc22d41-ebc9-4261-b02f-885b7b3ccba9.png)
