### PR TITLE
fix(Item-Sheet): 🐛 Display the roll item button when needed

### DIFF
--- a/src/item/item-sheet.js
+++ b/src/item/item-sheet.js
@@ -82,7 +82,7 @@ export default class BladeRunnerItemSheet extends ItemSheet {
     const originalButtons = super._getHeaderButtons();
     const myButtons = [];
 
-    if (this.item.rollable && this.item.actor) {
+    if (this.item.hasAction && this.item.actor) {
       myButtons.push({
         label: game.i18n.localize('FLBR.SHEET_HEADER.ItemRoll'),
         class: 'item-roll',


### PR DESCRIPTION
This PR fixes a small issue with the item sheet displaying a roll button in the header when there is no action defined