### PR TITLE
fix: 🔧 Repair the enrichHTML method inside Handlebars helpers

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,6 @@
 dist/
 node_modules
 foundry.js
+foundry-*.js
 static/system.json
 static/template.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ copy-packs.bat
 # Distribution Files
 /dist
 /foundry.js
+/foundry-*.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,6 @@ dist/
 .eslintrc
 package-lock.json
 foundry.js
+foundry-*.js
 static/system.json
 static/template.json

--- a/src/components/item-action.js
+++ b/src/components/item-action.js
@@ -64,7 +64,7 @@ export default class ItemAction {
   }
 }
 
-/** @enum {number} */
+/** @enum {string} */
 ItemAction.Types = {
   ROLL_SKILL: 'skill',
   RUN_MACRO: 'macro',

--- a/src/system/handlebars.js
+++ b/src/system/handlebars.js
@@ -108,11 +108,11 @@ function registerHandlebarsHelpers() {
   //   return undefined;
   // });
 
-  Handlebars.registerHelper('enrichText', function (text) {
-    // Enriches content.
-    text = TextEditor.enrichHTML(text, { documents: true, async: false });
-    return new Handlebars.SafeString(text);
-  });
+  // Handlebars.registerHelper('enrichText', function (text) {
+  //   // Enriches content.
+  //   text = TextEditor.enrichHTML(text, { documents: true, async: false });
+  //   return new Handlebars.SafeString(text);
+  // });
 
   Handlebars.registerHelper('enrichDocumentName', function (text) {
     const rgx = /@UUID\[(.+?)\](?:{(.+?)})?/gm;
@@ -121,7 +121,7 @@ function registerHandlebarsHelpers() {
       const title = p2 ?? fromUuidSync(p1)?.name ?? '{undefined}';
       return `<b>${title}</b>`;
     });
-    text = TextEditor.enrichHTML(text, { documents: true, async: false });
+    // text = TextEditor.enrichHTML(text, { documents: true, async: false });
     return new Handlebars.SafeString(text);
   });
 

--- a/src/system/handlebars.js
+++ b/src/system/handlebars.js
@@ -116,11 +116,14 @@ function registerHandlebarsHelpers() {
 
   Handlebars.registerHelper('enrichDocumentName', function (text) {
     const rgx = /@UUID\[(.+?)\](?:{(.+?)})?/gm;
-    text = text.replace(rgx, (_match, p1, p2) => {
+    if (rgx.test(text)) {
+      text = text.replace(rgx, (_match, p1, p2) => {
       // eslint-disable-next-line no-undef
-      const title = p2 ?? fromUuidSync(p1)?.name ?? '{undefined}';
-      return `<b>${title}</b>`;
-    });
+        const title = p2 ?? fromUuidSync(p1)?.name ?? '{undefined}';
+        return `<b>${title}</b>`;
+      });
+    }
+    // ! Next line removed because Foundry dropped support for async:
     // text = TextEditor.enrichHTML(text, { documents: true, async: false });
     return new Handlebars.SafeString(text);
   });


### PR DESCRIPTION
## Summary
<!-- Here goes a short summary about what the PR is about. -->
Since V12, `TextEditor.enrichHTML()` is now completely asynchronous and has dropped the `{ async: false }` option.

Consequently, the `enrichDocumentName` Handlebars' custom helper does not work anymore and returns a Promise "[object Promise]" instead of an enriched text.

This is an attempt to fix #46

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
