### PR TITLE
fix: 🐛 Add custom select helper and remove deprecation warnings

### DIFF
--- a/src/components/roll/templates/roller.hbs
+++ b/src/components/roll/templates/roller.hbs
@@ -54,11 +54,7 @@
 			{{!-- RollMode --}}
 			<h3>{{localize "CHAT.RollDefault"}}</h3>
 			<select name="rollMode">
-				{{#select rollMode}}
-					{{#each config.rollModes}}
-						<option value="{{@key}}">{{localize .}}</option>
-					{{/each}}
-				{{/select}}
+				{{selectOptions config.rollModes selected=rollMode localize=true}}
 			</select>
 			{{#if damage includeZero=true}}
 				<h3>{{localize "FLBR.WeaponDamage"}}:<span style="color: var(--color-green); float: right;">{{damage}}, <small>{{localize (lookup config.damageTypes damageType)}}</small></span></h3>

--- a/src/system/handlebars.js
+++ b/src/system/handlebars.js
@@ -129,6 +129,21 @@ function registerHandlebarsHelpers() {
   });
 
   /**
+   * Foundry's {{#select}} custom helper used here because pending removal from Foundry's code.
+   * A helper to assign an `<option>` within a `<select>` block as selected based on its value.
+   * Escape the string as handlebars would, then escape any regexp characters in it.
+   * Parameters:
+   * * `selected` - Value to be tagged as "selected"
+   * * `options` - options for the helper
+   */
+  Handlebars.registerHelper('select', function (selected, options) {
+    const escapedValue = RegExp.escape(Handlebars.escapeExpression(selected));
+    const rgx = new RegExp(` value=["']${escapedValue}["']`);
+    const html = options.fn(HandlebarsHelpers);
+    return html.replace(rgx, '$& selected');
+  });
+
+  /**
    * Templates for a die Score selector.
    * Parameters:
    * * `target` - The name of the affected variable.


### PR DESCRIPTION
## Summary
<!-- Here goes a short summary about what the PR is about. -->
Fix deprecation warnings for the use of `{{#select}}`.
- Changed one into {{selectOptions}}
- Created our own "select" custom helper to override the Foundry's one that is gonna disappear.

Tested on V10 and V12.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR adds a new feature that is not an open feature request.
- [X] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
