### PR TITLE
Fix push button on floating dice chat card

### DIFF
--- a/src/blade-runner.js
+++ b/src/blade-runner.js
@@ -207,7 +207,7 @@ Hooks.on('deleteActor', async actor => {
 
 Hooks.on('getChatMessageContextOptions', Chat.addChatMessageContextOptions);
 
-Hooks.on('renderChatLog', (_app, html, _data) => Chat.addChatListeners(html));
+Hooks.on('renderChatMessageHTML', (_app, html, _data) => Chat.addChatListeners(html));
 Hooks.on('renderChatMessageHTML', (_msg, html, _data) => Chat.hideChatActionButtons(html));
 
 /* -------------------------------------------- */

--- a/src/blade-runner.js
+++ b/src/blade-runner.js
@@ -207,7 +207,7 @@ Hooks.on('deleteActor', async actor => {
 
 Hooks.on('getChatMessageContextOptions', Chat.addChatMessageContextOptions);
 
-Hooks.on('renderChatMessageHTML', (_app, html, _data) => Chat.addChatListeners(html));
+Hooks.on('renderChatMessageHTML', (_msg, html, _data) => Chat.addChatListeners(html));
 Hooks.on('renderChatMessageHTML', (_msg, html, _data) => Chat.hideChatActionButtons(html));
 
 /* -------------------------------------------- */


### PR DESCRIPTION
## Summary
The chat floating card displays roll results with push and accept buttons, but it doesn't handle button clicks. This PR resolves this issue.

The buttons work well in the chat windows, so the `renderChatLog`  event occurs only for this case, but the `renderChatMessageHTML` works in both cases. I will propose a PR on YZUR.

<img width="441" height="348" alt="image" src="https://github.com/user-attachments/assets/d0335869-5b6c-4de7-98dc-ea69eb846439" />

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
